### PR TITLE
IV-4824 Relax rs_uid check

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -79,7 +79,7 @@ struct rs_user * read_next_policy_entry(FILE* fp, int* line_no) {
         gecos = strsep(&rawentryp, delimiters);
 
         if (preferred_name != NULL && unique_name != NULL && gecos != NULL &&
-            superuser != -1 && rs_uid > 500 && local_uid > 500) {
+            superuser != -1 && rs_uid > 0 && local_uid > 500) {
             entry_valid = TRUE;
         } else {
             NSS_DEBUG("%s:%d: Invalid format\n", POLICY_FILE, *line_no - 1);


### PR DESCRIPTION
Oops, rs_uid simply must be a positive integer for the entry to be valid.
